### PR TITLE
support empty project ID

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -68,7 +68,7 @@ func Init(ctx context.Context, opts LogOpts) error {
 		}
 	}
 
-	if !opts.DisableCloudLogging || opts.ProjectName == "" {
+	if !opts.DisableCloudLogging && opts.ProjectName != "" {
 		var err error
 		cloudLoggingClient, err = logging.NewClient(ctx, opts.ProjectName)
 		if err != nil {


### PR DESCRIPTION
this allows any error in setting the project name to disable cloud logging