### PR TITLE
try quieter

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -88,6 +88,9 @@ func Init(ctx context.Context, opts LogOpts) error {
 			return nil
 		}
 
+		// Override default error handler. Must be a func and not nil.
+		cloudLoggingClient.OnError = func(e error) { return }
+
 		// This automatically detects and associates with a GCE resource.
 		cloudLogger = cloudLoggingClient.Logger(loggerName)
 


### PR DESCRIPTION
in cases where we succeed in creating a logging client, but fail to log, the default log handler is invoked. this is because otherwise the user may be unaware that logs are being lost. in our cases where we almost always log duplex, this leads to noisy logs, with one error line alongside every log line. this will happen if e.g. used on an instance with no OAuth scopes configured.

this PR simply disables the onerror handler