### PR TITLE
logger: split Init()

### DIFF
--- a/logger/logger_unix.go
+++ b/logger/logger_unix.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// +build !windows
+//go:build !windows
 
 // Package logger logs messages as appropriate.
 package logger

--- a/logger/logger_windows.go
+++ b/logger/logger_windows.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// +build windows
+//go:build windows
 
 // Package logger logs messages as appropriate.
 package logger


### PR DESCRIPTION
Split the Init() function adding a SetupCloudlogging() function so the client may decide to set it up in a later stage of its initialization i.e.: only setup cloud logging after metadata is available in the VM.