### PR TITLE
Add timeout to `Close()` if flushing.

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -116,6 +116,14 @@ func Init(ctx context.Context, opts LogOpts) error {
 // Close closes the logger.
 func Close() {
 	if cloudLoggingClient != nil {
+		// Attempt to connect to Cloud Logging.
+		timeoutContext, cancelFunc := context.WithTimeout(context.Background(), time.Second*3)
+		defer cancelFunc()
+
+		if err := cloudLoggingClient.Ping(timeoutContext); err != nil {
+			Warningf("Cannot connect to cloud logging, skipping flush: %v", err)
+			return
+		}
 		cloudLogger.Flush()
 		cloudLoggingClient.Close()
 	}

--- a/logger/logger_unix.go
+++ b/logger/logger_unix.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// +build !windows
+//go:build !windows
 
 // Package logger logs messages as appropriate.
 package logger

--- a/logger/logger_windows.go
+++ b/logger/logger_windows.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-// +build windows
+//go:build windows
 
 // Package logger logs messages as appropriate.
 package logger


### PR DESCRIPTION
This is a workaround for the case where Cloud Logging isn't reachable, where the `Flush()` hangs indefinitely. Currently the timeout is set to 3 seconds. This workaround can be rolled back once a timeout is implemented in the Cloud Logging API.

/cc @ChaitanyaKulkarni28 @dorileo 