### PR TITLE
Resolve panic error in label map

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -132,7 +132,7 @@ func Init(ctx context.Context, opts LogOpts) error {
 		// resource. However instance_name is not included in this
 		// resource, so add an instance_name label to all log Entries.
 		name, err := metadata.InstanceName()
-		var labels map[string]string
+		labels := make(map[string]string)
 		if err == nil {
 			labels["instance_name"] = name
 		}


### PR DESCRIPTION
The labels map was not initialized, so that's what was causing the panic.

We'll need to update the go.mod again in `guest-agent` once this is merged.

/cc @ChaitanyaKulkarni28 @dorileo 